### PR TITLE
Added multiview support for 3D generation

### DIFF
--- a/backend/app/__init__.py
+++ b/backend/app/__init__.py
@@ -1,9 +1,9 @@
 import os
 from flask import Flask
-from config import config
-from services.generation.image_generator import ImageServiceRegistry
-from services.generation.prompt_generator import PromptServiceRegistry
-from services.generation.threeD_generator import ThreeDServiceRegistry
+from .config import config
+from app.services.generation.image_generator import ImageServiceRegistry
+from app.services.generation.prompt_generator import PromptServiceRegistry
+from app.services.generation.threeD_generator import ThreeDServiceRegistry
 
 
 def create_app(config_name=None):
@@ -16,13 +16,20 @@ def create_app(config_name=None):
     # Store registries in app.extensions for Blueprint access
     app.extensions['image_registry'] = ImageServiceRegistry(app.config)
     app.extensions['prompt_registry'] = PromptServiceRegistry(app.config)
-    app.extensions['3d_registery'] = ThreeDServiceRegistry(app.config)
+    app.extensions['3d_registry'] = ThreeDServiceRegistry(app.config)
 
-    from services.google_sheets_integration.sheets_manager import SheetManager
-    app.extensions['sheet_manager'] = SheetManager(
-        credentials=app.config['GOOGLE_SHEETS_CREDENTIALS_PATH'],
-        spreadsheet_id=app.config['GOOGLE_SHEET_ID']
-    )
+    from app.services.google_sheets_integration.sheets_manager import SheetManager
+    from app.services.google_sheets_integration.sheets_manager import MockSheetManager
+
+
+    if app.config.get('GOOGLE_SHEETS_CREDENTIALS_PATH'):
+        app.extensions['sheet_manager'] = SheetManager(
+            credentials=app.config['GOOGLE_SHEETS_CREDENTIALS_PATH'],
+            spreadsheet_id=app.config['GOOGLE_SHEET_ID']
+        )
+    else:
+        print("Using MockSheetManager (No credentials found)")
+        app.extensions['sheet_manager'] = MockSheetManager()
 
     # Register the Blueprint
     from .routes import api_bp

--- a/backend/app/routes.py
+++ b/backend/app/routes.py
@@ -28,20 +28,31 @@ def generate_image():
     if not service:
         return {'error': f'Service {service_choice} not supported'}, 400
 
-    image_bytes = service.generate(optimized_prompt)
-    if image_bytes:
+    images = service.generate(optimized_prompt, num_images = 3)
+    if images and len(images) > 0:
+        b64_images = []
+        for img_bytes in images:
+             # Encode to base64 string
+            b64_str = base64.b64encode(img_bytes).decode('utf-8')
+            # Add data URI prefix
+            b64_images.append(f"data:image/png;base64,{b64_str}")
+
         sheets_manager = current_app.extensions['sheet_manager']
         sheets_data = {
             "Image Generator": service_choice,
 
             # temp, need to convert bytes to image/link the file
-            "Image 1": image_bytes
+            "Image 1": None
         }
-        sheets_manager.update_row(sheets_data, "Sheet 1")
+        sheets_manager.update_row(sheets_data, "Sheet1")
 
-        return send_file(BytesIO(image_bytes), mimetype='image/png')
+        return jsonify({
+            'status': 'success',
+            'images': b64_images,
+            'count': len(b64_images)
+        }), 200
 
-    return {'error': 'Generation failed'}, 500
+    return {'error': 'Image Generation failed'}, 500
 
 
 @api_bp.route('/optimize-prompt', methods=['POST'])
@@ -70,7 +81,7 @@ def optimize_prompt():
             "Optimized Image Prompt": optimized_prompt,
             "System Prompt": SYSTEM_INSTRUCTION,
         }
-        sheets_manager.update_row(sheets_data, "Sheet 1")
+        sheets_manager.update_row(sheets_data, "Sheet1")
 
         return {
             'success': True,
@@ -81,7 +92,7 @@ def optimize_prompt():
 
     return {'error': 'Prompt optimization failed'}, 500
 
-@api_bp.route('/api/generate-3d-model', methods=['POST'])
+@api_bp.route('/generate-3d-model', methods=['POST'])
 def generate_3d_model():
     data = request.get_json()
 
@@ -104,7 +115,7 @@ def generate_3d_model():
         # Decode base64 strings to bytes
         image_bytes_list = []
         for img_str in images_data:
-            # Strip metadata header (e.g., "data:image/png;base64,") if present
+            # Strip metadata header (e.g., "data:image/png;base64,")
             if ',' in img_str:
                 img_str = img_str.split(',')[1]
             image_bytes_list.append(base64.b64decode(img_str))
@@ -122,7 +133,7 @@ def generate_3d_model():
             # temp, need to convert bytes to 3d model/link the file
             "Model link": model_bytes
         }
-        sheets_manager.update_row(sheets_data, "Sheet 1")
+        sheets_manager.update_row(sheets_data, "Sheet1")
 
         # Return the GLB file
         return send_file(
@@ -133,8 +144,8 @@ def generate_3d_model():
         )
 
     except Exception as e:
-        print(f"3D Generation Error: {e}")
-        return {'error': str(e)}, 500
+        print(f"3D Generation Error Type: {type(e).__name__}")
+        return {'error': 'Internal server error during 3D generation'}, 500
 
 @api_bp.route('/available-models', methods=['GET'])
 def available_models():
@@ -147,7 +158,7 @@ def available_models():
         case "image":
             registry = current_app.extensions['image_registry']
         case "3D":
-            registry = current_app.extensions['3D_registry']
+            registry = current_app.extensions['3d_registry']
         case _:
             return {'error': 'Invalid asset type'}, 400
 

--- a/backend/app/services/generation/image_generator.py
+++ b/backend/app/services/generation/image_generator.py
@@ -28,7 +28,7 @@ class ImageServiceRegistry:
 
 class BaseImageGenerator(ABC):
     @abstractmethod
-    def generate(self, prompt: str):
+    def generate(self, prompt: str, num_images: int = 1) -> list[bytes]:
         pass
 
 # Imagen-4.0
@@ -40,18 +40,18 @@ class Imagen(BaseImageGenerator):
         )
         self.model_name = 'imagen-4.0-generate-001'
 
-    def generate(self, prompt: str):
+    def generate(self, prompt: str, num_images: int = 1):
         try:
             response = self.client.models.generate_images(
                 model='imagen-4.0-generate-001',
                 prompt=prompt,
-                config=types.GenerateImagesConfig(number_of_images=1)
+                config=types.GenerateImagesConfig(number_of_images=num_images)
             )
             if response.generated_images:
-                return response.generated_images[0].image.image_bytes
+                return [img.image.image_bytes for img in response.generated_images]
         except Exception as e:
-            print(f"Imagen Error: {e}")
-        return None
+            print(f"imagen-4.0-generate-001 Error: {e}")
+        return []
 
 # Nano-Banana-pro
 class NanoBanana(BaseImageGenerator):
@@ -63,22 +63,27 @@ class NanoBanana(BaseImageGenerator):
 
         self.model_name = 'gemini-3-pro-image-preview'
 
-    def generate(self, prompt: str):
+    def generate(self, prompt: str, num_images: int = 1):
         try:
             response = self.client.models.generate_content(
                 model=self.model_name,
                 contents=prompt,
                 config=types.GenerateContentConfig(
-                    response_modalities=['IMAGE']
+                    response_modalities=['IMAGE'],
+                    candidate_count=num_images
                 )
             )
-            for part in response.candidates[0].content.parts:
-                if part.inline_data:
-                    return part.inline_data.data
+            images = []
+            if response.candidates:
+                for candidate in response.candidates:
+                    for part in candidate.content.parts:
+                        if part.inline_data:
+                            images.append(part.inline_data.data)
+            return images
                 
         except Exception as e:
-            print(f"Nano Banana Error: {e}")
-        return None
+            print(f"Nano Banana Pro Error: {e}")
+        return []
 
 # GPT-image-1.5
 class GPT_image(BaseImageGenerator):
@@ -86,31 +91,33 @@ class GPT_image(BaseImageGenerator):
         self.client = OpenAI(api_key=api_key)
         self.model_name = "gpt-image-1.5"
 
-    def generate(self, prompt: str):
+    def generate(self, prompt: str, num_images: int = 1):
         try:
             response = self.client.images.generate(
                 model=self.model_name,
                 prompt=prompt,
-                n=1
+                n=num_images
                 # size and quality omitted
             )
+            images = []
+            for item in response.data:
+                if item.b64_json:
+                    images.append(base64.b64decode(item.b64_json))
             
-            image_base64 = response.data[0].b64_json
-            image_bytes = base64.b64decode(image_base64)
-            
-            return image_bytes
+            return images
             
         except Exception as e:
-            print(f"OpenAI Error: {e}")
-        return None
+            print(f"GPT-image-1.5 Error: {e}")
+        return []
 
 # Used for testing in case an API key fails
 class MockImageGenerator(BaseImageGenerator):
-    def generate(self, prompt: str):
+    def generate(self, prompt: str, num_images: int = 1):
         # Creates a 100x100 solid blue square
         img = Image.new('RGB', (100, 100), color='blue')
         img_byte_arr = io.BytesIO()
         img.save(img_byte_arr, format='PNG')
+        bytes_data = img_byte_arr.getvalue()
         
         print(f"DEBUG: Mock Generator used for prompt: {prompt}")
-        return img_byte_arr.getvalue()
+        return [bytes_data] * num_images

--- a/backend/app/services/generation/threeD_generator.py
+++ b/backend/app/services/generation/threeD_generator.py
@@ -33,59 +33,69 @@ class Base3DGenerator(ABC):
     def _bytes_to_data_uri(self, image_bytes: bytes, mime_type: str = "image/png") -> str:
         base64_str = base64.b64encode(image_bytes).decode('utf-8')
         return f"data:{mime_type};base64,{base64_str}"
-
+    
+    # Robustly extracts the GLB URL from various fal.ai response formats.
+    def _extract_url(self, result, service_name):
+        # Handle different response structures
+        if 'model_mesh' in result:
+             return result['model_mesh']['url']
+        if 'model_glb' in result: # Trellis 2 often uses this key
+             return result['model_glb']['url']
+        
+        if 'results' in result and isinstance(result['results'], list):
+            for item in result['results']:
+                if item.get('file_name', '').endswith('.glb'):
+                    return item['url']
+        raise ValueError(f"Could not find model URL in {service_name} response. Keys found: {list(result.keys())}")
+    
     # Helper to download the generated 3D model file.
     def _download_file(self, url: str) -> bytes:
         response = requests.get(url)
         response.raise_for_status()
         return response.content
-    
-    # Robustly extracts the GLB URL from various fal.ai response formats.
-    def _extract_url(self, result: dict, service_name: str) -> str:
-        # Try common keys used by Trellis and Hunyuan
-        for key in ['model_mesh', 'model_glb']:
-            if key in result and isinstance(result[key], dict) and 'url' in result[key]:
-                return result[key]['url']
-        
-        # Log the full result for debugging if no key is found
-        print(f"DEBUG: {service_name} API returned: {result}")
-        raise ValueError(f"{service_name} output does not contain a valid model URL.")
 
 class Trellis(Base3DGenerator):
     def __init__(self):
-        self.model_endpoint = "fal-ai/trellis"
+        self.model_endpoint = "fal-ai/trellis/multi"
 
     def generate(self, images: list[bytes]) -> bytes:
         if not images:
             return None
+        
+        image_urls = [self._bytes_to_data_uri(img) for img in images]
         
         try:
             result = fal_client.subscribe(
                 self.model_endpoint,
                 # Update later for multiview support
-                arguments={"image_url": self._bytes_to_data_uri(images[0])}
+                arguments={"image_urls": image_urls}
             )
             
             model_url = self._extract_url(result, "Trellis")
             return self._download_file(model_url)
         except Exception as e:
-            print(f"Trellis3D Error: {e}")
+            print(f"Trellis3D Error: {str(e)[:200]}...")
             return None
 
 class Hunyuan(Base3DGenerator):
     def __init__(self):
-        self.model_endpoint = "fal-ai/hunyuan3d/v2"
+        self.model_endpoint = "fal-ai/hunyuan3d/v2/multi-view"
 
     def generate(self, images: list[bytes]) -> bytes:
-        if not images:
+        if not images or len(images) < 3:
+            print("Hunyuan3D requires at least 3 images (Front, Back, Left)")
             return None
 
-        # Update later for multiview support
-        arguments = {
-            "input_image_url": self._bytes_to_data_uri(images[0])
-        }
-
         try:
+            arguments = {
+                "front_image_url": self._bytes_to_data_uri(images[0]),
+                "back_image_url": self._bytes_to_data_uri(images[1]),
+                "left_image_url": self._bytes_to_data_uri(images[2])
+                
+            }
+            if len(images) == 4:
+                arguments["right_image_url"] = self._bytes_to_data_uri(images[3])
+            
             result = fal_client.subscribe(
                 self.model_endpoint,
                 arguments=arguments

--- a/backend/app/services/google_sheets_integration/sheets_manager.py
+++ b/backend/app/services/google_sheets_integration/sheets_manager.py
@@ -5,6 +5,12 @@ Implemented as a singleton to ensure a single point of data persistence.
 
 from app.services.google_sheets_integration.sheets_client import GoogleSheetsClient
 
+class MockSheetManager:
+    def __init__(self, *args, **kwargs):
+        pass
+    def update_row(self, data, sheet_name):
+        print(f"MockSheetManager: Skipping write for {sheet_name}")
+
 class SheetManager:
     _instance = None
     _initialized = False

--- a/backend/test/test_3Dgen.py
+++ b/backend/test/test_3Dgen.py
@@ -1,63 +1,81 @@
 import requests
 import base64
 import os
+import json
 
 BASE_URL = "http://127.0.0.1:5055"
 PROMPT = "A cute isometric low-poly style cottage with a red roof, white walls, on a floating island"
-IMAGE_SERVICE = "imagen"  # Options: imagen, nano-banana, GPT-image
-THREED_SERVICE = "trellis" # Options: trellis, hunyuan
+IMAGE_SERVICE = "imagen"   # Options: imagen, nano-banana, GPT-image
+THREED_SERVICE = "trellis" # Options: trellis, hunyuan (Hunyuan requires >3 images)
 
 def run_pipeline():
     print(f"--- Starting Pipeline ---")
     
-    # ---------------------------------------------------------
-    # STEP 1: Generate the 2D Image
-    # ---------------------------------------------------------
-    print(f"1. Generating image with prompt: '{PROMPT}'...")
-    
-    img_response = requests.post(
-        f"{BASE_URL}/api/generate-image",
-        json={"prompt": PROMPT, "service": IMAGE_SERVICE}
-    )
-
-    if img_response.status_code != 200:
-        print(f"Error generating image: {img_response.text}")
-        return
-
-    # The image service returns raw binary data (image/png)
-    image_bytes = img_response.content
-    
-    # Save the intermediate image for verification
-    with open("intermediate_image.png", "wb") as f:
-        f.write(image_bytes)
-    print("   -> Image generated and saved as 'intermediate_image.png'")
-
-    # ---------------------------------------------------------
-    # STEP 2: Generate the 3D Model
-    # ---------------------------------------------------------
-    print(f"2. Generating 3D model using {THREED_SERVICE}...")
-
-    # The 3D service expects a JSON list of Base64 strings
-    # Encode the binary image data received
-    base64_image = base64.b64encode(image_bytes).decode('utf-8')
+    # Generate images
+    print(f"1. Generating images with prompt: '{PROMPT}'...")
     
     payload = {
-        "images": [base64_image], 
+        "optimized_prompt": PROMPT, 
+        "service": IMAGE_SERVICE,
+        "num_images": 3 
+    }
+    
+    try:
+        img_response = requests.post(
+            f"{BASE_URL}/api/generate-image",
+            json=payload
+        )
+        img_response.raise_for_status() # Raise error for 400/500 codes
+    except requests.exceptions.RequestException as e:
+        print(f"Error generating image: {e}")
+        if img_response: print(img_response.text)
+        return
+
+    # Handle JSON response containing list of images
+    response_data = img_response.json()
+    
+    # Extract the list of data URI strings ("data:image/png;base64,...")
+    images_data = response_data.get('images', [])
+    
+    if not images_data:
+        print("No images returned from service.")
+        return
+        
+    print(f"   -> Received {len(images_data)} images.")
+
+    # Save intermediate images for verification
+    for idx, img_str in enumerate(images_data):
+        # Strip the header "data:image/png;base64," to save as file
+        if ',' in img_str:
+            base64_data = img_str.split(',')[1]
+        else:
+            base64_data = img_str
+            
+        with open(f"intermediate_image_{idx}.png", "wb") as f:
+            f.write(base64.b64decode(base64_data))
+    
+    print("   -> Intermediate images saved locally.")
+
+    # Generate 3D Model
+    print(f"2. Generating 3D model using {THREED_SERVICE}...")
+
+    payload_3d = {
+        "images": images_data, 
         "service": THREED_SERVICE
     }
 
-    three_d_response = requests.post(
-        f"{BASE_URL}/api/generate-3d-model",
-        json=payload
-    )
-
-    if three_d_response.status_code != 200:
-        print(f"Error generating 3D model: {three_d_response.text}")
+    try:
+        three_d_response = requests.post(
+            f"{BASE_URL}/api/generate-3d-model",
+            json=payload_3d
+        )
+        three_d_response.raise_for_status()
+    except requests.exceptions.RequestException as e:
+        print(f"Error generating 3D model: {e}")
+        if three_d_response: print(three_d_response.text)
         return
 
-    # ---------------------------------------------------------
-    # STEP 3: Save the Result
-    # ---------------------------------------------------------
+    # Save result
     output_filename = f"final_model_{THREED_SERVICE}.glb"
     with open(output_filename, "wb") as f:
         f.write(three_d_response.content)


### PR DESCRIPTION
Modified image generation to accept a parameter for number of images to create. Need to modify prompt optimization module to generate multiple views of the same object rather than just the same view multiple times.

3D generation with Hunyuan3D v2 and TRELLIS.1-multi now work with multiple images. TRELLIS.2-multi will be implemented later, couldn't find a lot of documentation on how to get it working through fal ai.

Added a MockSheetsManager class to sheets_manager.py to avoid uploading to a Google Sheet when testing functionality.

test_3Dgen.py is also updated to support everything mentioned here.