### PR TITLE
image and model upload working, changed Google authentication to oauth

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 # Credentials
 credentials.json
+token.json
 
 # Environment variables and API keys
 .env

--- a/backend/app/__init__.py
+++ b/backend/app/__init__.py
@@ -6,8 +6,6 @@ from .services.generation.prompt_generator import PromptServiceRegistry
 from .services.generation.threeD_generator import ThreeDServiceRegistry
 from .services.quality_control.clip_scorer import ClipScorerService
 
-
-
 def create_app(config_name=None):
     if config_name is None:
         config_name = os.getenv('FLASK_ENV', 'default')
@@ -23,6 +21,7 @@ def create_app(config_name=None):
 
     from .services.google_sheets_integration.sheets_manager import SheetManager
     from .services.google_sheets_integration.sheets_manager import MockSheetManager
+    from .services.google_sheets_integration.drive_uploader import GoogleDriveUploader
 
 
     if app.config.get('GOOGLE_SHEETS_CREDENTIALS_PATH'):
@@ -30,9 +29,13 @@ def create_app(config_name=None):
             credentials=app.config['GOOGLE_SHEETS_CREDENTIALS_PATH'],
             spreadsheet_id=app.config['GOOGLE_SHEET_ID']
         )
+        app.extensions['drive_uploader'] = GoogleDriveUploader(
+            credentials_path=app.config['GOOGLE_SHEETS_CREDENTIALS_PATH']
+        )
     else:
         print("Using MockSheetManager (No credentials found)")
         app.extensions['sheet_manager'] = MockSheetManager()
+        app.extensions['drive_uploader'] = None
 
     # Register the Blueprint
     from .routes import api_bp

--- a/backend/app/__init__.py
+++ b/backend/app/__init__.py
@@ -22,20 +22,23 @@ def create_app(config_name=None):
     from .services.google_sheets_integration.sheets_manager import SheetManager
     from .services.google_sheets_integration.sheets_manager import MockSheetManager
     from .services.google_sheets_integration.drive_uploader import GoogleDriveUploader
+    from .services.google_sheets_integration.drive_uploader import MockDriveUploader
 
+    creds_path = app.config.get('GOOGLE_SHEETS_CREDENTIALS_PATH')
 
-    if app.config.get('GOOGLE_SHEETS_CREDENTIALS_PATH'):
+    if creds_path and os.path.exists(creds_path):
+        print("🟢 credentials.json found. Initializing real Google APIs...")
         app.extensions['sheet_manager'] = SheetManager(
-            credentials=app.config['GOOGLE_SHEETS_CREDENTIALS_PATH'],
+            credentials=creds_path,
             spreadsheet_id=app.config['GOOGLE_SHEET_ID']
         )
         app.extensions['drive_uploader'] = GoogleDriveUploader(
-            credentials_path=app.config['GOOGLE_SHEETS_CREDENTIALS_PATH']
+            credentials_path=creds_path
         )
     else:
-        print("Using MockSheetManager (No credentials found)")
+        print("🟡 credentials.json NOT FOUND. Falling back to Mock Services.")
         app.extensions['sheet_manager'] = MockSheetManager()
-        app.extensions['drive_uploader'] = None
+        app.extensions['drive_uploader'] = MockDriveUploader()
 
     # Register the Blueprint
     from .routes import api_bp

--- a/backend/app/routes.py
+++ b/backend/app/routes.py
@@ -1,6 +1,7 @@
 import zipfile
 import base64
 import json
+import uuid
 
 from flask import Blueprint, request, send_file, jsonify, current_app
 from app.services.generation.threeD_generator import split_orthographic_sheet
@@ -158,7 +159,6 @@ def available_models():
 
     services = list(registry.get_services().keys())
 
-
     return jsonify({'services': services}), 200
 
 
@@ -180,8 +180,7 @@ def evaluate_image():
         
         if scorer:
             try:
-                # The frontend sends "data:image/png;base64,iVBORw..."
-                # We need to strip the prefix to decode the raw bytes
+                # Strip the prefix to decode the raw bytes
                 if ',' in img_str:
                     b64_data = img_str.split(',')[1]
                 else:
@@ -225,7 +224,7 @@ def convert_model():
             # Export the scene to OBJ
             export_data = scene.export(file_type='obj', include_texture=True, return_texture=True)
 
-            # FIX: If trimesh returns a tuple like (obj_string, texture_dictionary)
+            # If trimesh returns a tuple like (obj_string, texture_dictionary)
             if isinstance(export_data, tuple):
                 obj_content = export_data[0]
                 textures = export_data[1] if len(export_data) > 1 else {}
@@ -289,8 +288,84 @@ def save_job():
 
     try:
         sheets_manager = current_app.extensions['sheet_manager']
+        uploader = current_app.extensions['drive_uploader']
 
-        # Consolidate all data into a single row update, gracefully handling missing data
+        # Helper to handle text statuses ("pending", etc) without crashing
+        def process_text_status(val):
+            if val in ["pending", "Pending"]:
+                return "Still generating..."
+            if len(str(val)) > 1000:
+                return "Image data too large for Sheets"
+            return val
+
+        # Grab the full grid image. 
+        raw_image_data = data.get('image_3')
+        if not raw_image_data or not str(raw_image_data).startswith('data:image'):
+            raw_image_data = data.get('image_1', '')
+            
+        # Initialize 4 sheet columns
+        sheet_images = ["", "", "", ""]
+
+        # If valid image, split it and upload
+        if raw_image_data and str(raw_image_data).startswith('data:image'):
+            # Strip the "data:image/png;base64," prefix
+            b64_str = raw_image_data.split(',')[1] if ',' in raw_image_data else raw_image_data
+            
+            try:
+                # Decode base64 to raw bytes
+                img_bytes = base64.b64decode(b64_str)
+                
+                split_images_bytes = split_orthographic_sheet(img_bytes)
+                
+                for i, quadrant_bytes in enumerate(split_images_bytes):
+                    if uploader:
+                        # Convert bytes back to base64 for the Drive Uploader
+                        quadrant_b64 = base64.b64encode(quadrant_bytes).decode('utf-8')
+                        filename = f"generated_img_{uuid.uuid4().hex[:8]}_quadrant_{i+1}.png"
+                        
+                        url = uploader.upload_base64_image(quadrant_b64, filename)
+                        if url:
+                            raw_image_url = url.replace('export=view', 'export=download')
+                            
+                            # Wraps the IMAGE formula in a HYPERLINK formula
+                            sheet_images[i] = f'=HYPERLINK("{url}", IMAGE("{raw_image_url}"))'
+                        else:
+                            sheet_images[i] = "Drive Upload Failed"
+            except Exception as e:
+                print(f"Error splitting/uploading images: {e}")
+                sheet_images = ["Split Failed"] * 4
+        else:
+            status = process_text_status(raw_image_data)
+            sheet_images = [status] * 4
+            
+        # 3D MODEL UPLOAD
+        raw_model_data = data.get('model_data')
+        model_link_for_sheet = data.get('model_link', '')
+
+        if raw_model_data and str(raw_model_data).startswith('data:'):
+            try:
+                # Dynamically pull the mime type if it exists in the data URI (e.g., data:model/gltf-binary;base64,...)
+                mime_type = 'application/octet-stream'
+                if ';' in raw_model_data:
+                    mime_type = raw_model_data.split(';')[0].replace('data:', '')
+
+                # Give it a unique name
+                ext = '.glb' if 'gltf' in mime_type or 'glb' in mime_type else '.obj'
+                model_filename = f"model_{uuid.uuid4().hex[:8]}{ext}"
+
+                # Upload to Drive
+                if uploader:
+                    model_drive_url = uploader.upload_base64_file(raw_model_data, model_filename, mime_type)
+                    if model_drive_url:
+                        # Make a link in the Google Sheet
+                        model_link_for_sheet = f'=HYPERLINK("{model_drive_url}", "View 3D Model")'
+                    else:
+                        model_link_for_sheet = "Upload Failed"
+            except Exception as e:
+                print(f"Error uploading 3D model: {e}")
+                model_link_for_sheet = "Upload Failed"
+        # ----------------------------------
+
         sheets_data = {
             "User": data.get('user', ''),
             "Description": data.get('description', ''),
@@ -299,18 +374,19 @@ def save_job():
             "System Prompt": SYSTEM_INSTRUCTION,
             "Optimized Image Prompt": data.get('optimized_prompt', ''),
             "Image Generator": data.get('image_model', ''),
-            "Image 1": data.get('image_1', ''),
-            "Image 2": data.get('image_2', ''),
-            "Image 3": data.get('image_3', ''),
-            "Image 4": data.get('image_4', ''),
+            "Image 1": sheet_images[0],
+            "Image 2": sheet_images[1],
+            "Image 3": sheet_images[2],
+            "Image 4": sheet_images[3],
             "3D Model Generator": data.get('three_d_model', ''),
-            "Model link": data.get('model_link', ''),
+            "Model link": model_link_for_sheet,
             "Analysis": data.get('analysis', ''),
         }
 
-        sheets_manager.update_row(sheets_data, "Sheet1")
+        sheets_manager.add_entry(sheets_data, "Sheet1")
 
         return jsonify({'status': 'success'}), 200
+        
     except Exception as e:
         print(f"Failed to save job to Sheets: {e}")
         return {'error': 'Failed to save job to Sheets'}, 500

--- a/backend/app/services/generation/threeD_generator.py
+++ b/backend/app/services/generation/threeD_generator.py
@@ -191,7 +191,7 @@ class HunyuanPro(Base3DGenerator):
                 arguments=arguments
             )
             
-            # v3.1 Pro returns the URL in a 'model_glb' dict, which your _extract_url already handles!
+            # v3.1 Pro returns the URL in a 'model_glb' dict
             model_url = self._extract_url(result, "HunyuanPro")
             return self._download_file(model_url)
             

--- a/backend/app/services/google_sheets_integration/drive_uploader.py
+++ b/backend/app/services/google_sheets_integration/drive_uploader.py
@@ -8,6 +8,18 @@ from google_auth_oauthlib.flow import InstalledAppFlow
 from googleapiclient.discovery import build
 from googleapiclient.http import MediaIoBaseUpload
 
+class MockDriveUploader:
+    def __init__(self, *args, **kwargs):
+        print("🟡 MockDriveUploader initialized (Bypassing Google Drive).")
+
+    def upload_base64_image(self, b64_string: str, filename: str) -> str:
+        print(f"🟡 [MOCK] Uploading image: {filename}")
+        return "https://mock-drive-link.com/fake-image.png"
+
+    def upload_base64_file(self, b64_string: str, filename: str, mime_type: str = 'application/octet-stream') -> str:
+        print(f"🟡 [MOCK] Uploading 3D model: {filename}")
+        return "https://mock-drive-link.com/fake-model.glb"
+
 class GoogleDriveUploader:
     SCOPES = [
         'https://www.googleapis.com/auth/drive.file',

--- a/backend/app/services/google_sheets_integration/drive_uploader.py
+++ b/backend/app/services/google_sheets_integration/drive_uploader.py
@@ -1,0 +1,128 @@
+import base64
+import io
+import os
+import os.path
+from google.auth.transport.requests import Request
+from google.oauth2.credentials import Credentials
+from google_auth_oauthlib.flow import InstalledAppFlow
+from googleapiclient.discovery import build
+from googleapiclient.http import MediaIoBaseUpload
+
+class GoogleDriveUploader:
+    SCOPES = [
+        'https://www.googleapis.com/auth/drive.file',
+        'https://www.googleapis.com/auth/spreadsheets'
+    ]
+
+    def __init__(self, credentials_path=None):
+        self.folder_id = os.getenv('DRIVE_FOLDER_ID')
+
+        if not credentials_path or not os.path.exists(credentials_path):
+            current_dir = os.path.dirname(os.path.abspath(__file__))
+            credentials_path = os.path.join(current_dir, 'credentials.json')
+            
+        if not os.path.exists(credentials_path):
+            raise FileNotFoundError(f"DriveUploader could not find credentials at: {credentials_path}")
+
+        # Path for the token.json file to save user login
+        token_path = os.path.join(os.path.dirname(credentials_path), 'token.json')
+        creds = None
+
+        if os.path.exists(token_path):
+            creds = Credentials.from_authorized_user_file(token_path, self.SCOPES)
+        
+        # If there are no (valid) credentials available, let the user log in.
+        if not creds or not creds.valid:
+            if creds and creds.expired and creds.refresh_token:
+                creds.refresh(Request())
+            else:
+                flow = InstalledAppFlow.from_client_secrets_file(
+                    credentials_path, self.SCOPES)
+                creds = flow.run_local_server(port=0)
+            
+            # Save the credentials for the next run
+            with open(token_path, 'w') as token:
+                token.write(creds.to_json())
+
+        self.creds = creds
+        self.service = build('drive', 'v3', credentials=self.creds)
+
+
+    # FOR IMAGES
+    def upload_base64_image(self, b64_string: str, filename: str) -> str:
+        try:
+            if ',' in b64_string:
+                b64_string = b64_string.split(',')[1]
+
+            image_bytes = base64.b64decode(b64_string)
+            file_stream = io.BytesIO(image_bytes)
+
+            file_metadata = {'name': filename}
+            
+            if self.folder_id:
+                file_metadata['parents'] = [self.folder_id]
+
+            media = MediaIoBaseUpload(file_stream, mimetype='image/png', resumable=True)
+
+            uploaded_file = self.service.files().create(
+                body=file_metadata,
+                media_body=media,
+                fields='id',
+                supportsAllDrives=True
+            ).execute()
+
+            file_id = uploaded_file.get('id')
+
+            self.service.permissions().create(
+                fileId=file_id,
+                body={'type': 'anyone', 'role': 'reader'}
+            ).execute()
+
+            # Specific URL format required for Google Sheets =IMAGE() to work
+            return f'https://drive.google.com/uc?export=view&id={file_id}'
+
+        except Exception as e:
+            print(f"Drive Upload Error (Image): {e}")
+            return ""
+
+
+    # FOR 3D MODELS
+    def upload_base64_file(self, b64_string: str, filename: str, mime_type: str = 'application/octet-stream') -> str:
+        """Uploads any base64 encoded file to Google Drive and returns a viewing link."""
+        try:
+            if ',' in b64_string:
+                # Extract the base64 part if it has a "data:..." prefix
+                b64_string = b64_string.split(',')[1]
+
+            file_bytes = base64.b64decode(b64_string)
+            file_stream = io.BytesIO(file_bytes)
+
+            file_metadata = {'name': filename}
+            
+            if self.folder_id:
+                file_metadata['parents'] = [self.folder_id]
+
+            # Upload the file using the dynamic mime_type
+            media = MediaIoBaseUpload(file_stream, mimetype=mime_type, resumable=True)
+
+            uploaded_file = self.service.files().create(
+                body=file_metadata,
+                media_body=media,
+                fields='id',
+                supportsAllDrives=True
+            ).execute()
+
+            file_id = uploaded_file.get('id')
+
+            # Make the file readable by anyone with the link
+            self.service.permissions().create(
+                fileId=file_id,
+                body={'type': 'anyone', 'role': 'reader'}
+            ).execute()
+
+            # Standard Google Drive viewing/download link for UI clickability
+            return f'https://drive.google.com/file/d/{file_id}/view?usp=sharing'
+
+        except Exception as e:
+            print(f"Drive Upload Error (File): {e}")
+            return ""

--- a/backend/app/services/google_sheets_integration/sheets_client.py
+++ b/backend/app/services/google_sheets_integration/sheets_client.py
@@ -1,12 +1,18 @@
 import os
-from google.oauth2.service_account import Credentials
+import os.path
+from google.auth.transport.requests import Request
+from google.oauth2.credentials import Credentials
+from google_auth_oauthlib.flow import InstalledAppFlow
 from googleapiclient.discovery import build
 from googleapiclient.errors import HttpError
 
 
 class GoogleSheetsClient:
 
-    SCOPES = ['https://www.googleapis.com/auth/spreadsheets']
+    SCOPES = [
+        'https://www.googleapis.com/auth/drive.file',
+        'https://www.googleapis.com/auth/spreadsheets'
+    ]
 
     def __init__(self, credentials):
         self.creds = None
@@ -18,14 +24,33 @@ class GoogleSheetsClient:
         self._authenticate()
 
     def _authenticate(self):
-        """Authenticates using Service Account credentials"""
+        """Authenticates using OAuth 2.0 credentials"""
         try:
-            if not os.path.exists(self.credentials_source):
-                raise FileNotFoundError(f"Credentials file not found at: {self.credentials_source}")
+            creds = None
+            # Define path for token.json next to credentials.json
+            token_path = os.path.join(os.path.dirname(self.credentials_source), 'token.json')
 
-            self.creds = Credentials.from_service_account_file(
-                self.credentials_source, scopes=self.SCOPES)
+            # Load existing user token if it exists
+            if os.path.exists(token_path):
+                creds = Credentials.from_authorized_user_file(token_path, self.SCOPES)
+            
+            # If no valid credentials, run the OAuth flow
+            if not creds or not creds.valid:
+                if creds and creds.expired and creds.refresh_token:
+                    creds.refresh(Request())
+                else:
+                    if not os.path.exists(self.credentials_source):
+                        raise FileNotFoundError(f"OAuth Credentials file not found at: {self.credentials_source}")
+                    
+                    flow = InstalledAppFlow.from_client_secrets_file(
+                        self.credentials_source, self.SCOPES)
+                    creds = flow.run_local_server(port=0)
+                
+                # Save the credentials for the next run
+                with open(token_path, 'w') as token:
+                    token.write(creds.to_json())
 
+            self.creds = creds
             self.service = build('sheets', 'v4', credentials=self.creds)
 
         except Exception as e:

--- a/backend/app/services/google_sheets_integration/sheets_manager.py
+++ b/backend/app/services/google_sheets_integration/sheets_manager.py
@@ -6,9 +6,20 @@ from app.services.google_sheets_integration.sheets_client import GoogleSheetsCli
 
 class MockSheetManager:
     def __init__(self, *args, **kwargs):
-        pass
+        print("MockSheetManager initialized (Bypassing Google Sheets).")
+        
+    def add_entry(self, data_dict, sheet_name="Sheet1"):
+        print(f"[MOCK] Saving Job to Sheets -> Sheet: {sheet_name}")
+        print(f"[MOCK] Job Data: User={data_dict.get('User')}, Model={data_dict.get('3D Model Generator')}")
+        raise Exception("Mock services are active. Actual upload was bypassed.")
+
     def update_row(self, data, sheet_name):
-        print(f"MockSheetManager: Skipping write for {sheet_name}")
+        print(f"[MOCK] Skipping row update for {sheet_name}")
+        return True
+        
+    def get_headers(self, sheet_name):
+        print(f"[MOCK] Getting headers for {sheet_name}")
+        return []
 
 class SheetManager:
     _instance = None

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -1,6 +1,8 @@
 Flask==3.1.2
 google-api-python-client==2.188.0
 google-auth==2.47.0
+google-auth-httplib2
+google-auth-oauthlib
 python-dotenv==1.2.1
 google-genai
 huggingface-hub

--- a/frontend/src/components/Dashboard.jsx
+++ b/frontend/src/components/Dashboard.jsx
@@ -3,6 +3,16 @@ import React, { useState, useEffect, useRef } from 'react';
 import './Dashboard.css';
 import '@google/model-viewer' // npm install @google/model-viewer
 
+// Helper function to convert Blob to Base64
+const blobToBase64 = (blob) => {
+  return new Promise((resolve, reject) => {
+    const reader = new FileReader();
+    reader.onloadend = () => resolve(reader.result);
+    reader.onerror = reject;
+    reader.readAsDataURL(blob);
+  });
+};
+
 const Dashboard = () => {
   // State management for prompt optimization
   const [inputPrompt, setInputPrompt] = useState("A futuristic, sleek white chair with blue LED light accents");
@@ -228,9 +238,7 @@ const Dashboard = () => {
                 };
               });
 
-              // --- NEW SORTING LOGIC ---
               // Sort the array in descending order (highest score first)
-              // We use a fallback to 0 in case a score somehow comes back as "N/A"
               scoredResults.sort((a, b) => {
                 const scoreA = typeof a.score === 'number' ? a.score : 0;
                 const scoreB = typeof b.score === 'number' ? b.score : 0;
@@ -312,7 +320,7 @@ const Dashboard = () => {
     setIsDownloading(true);
 
     try {
-      // FAST PATH: If they want the native GLB, we don't need the backend!
+      // FAST PATH: If user wants GLB, don't use backend
       if (downloadFormat === 'glb') {
           const link = document.createElement('a');
           link.href = modelUrl;
@@ -324,17 +332,16 @@ const Dashboard = () => {
           return;
       }
 
-      // CONVERSION PATH: Send the blob to the backend for OBJ/FBX
-      // 1. Fetch the binary blob from our local model viewer
+      // Fetch the binary blob from our local model viewer
       const localResponse = await fetch(modelUrl);
       const blobData = await localResponse.blob();
 
-      // 2. Attach it to a form payload
+      // Attach it to a form payload
       const formData = new FormData();
       formData.append('model_file', blobData, 'model.glb');
       formData.append('format', downloadFormat);
 
-      // 3. Request conversion
+      // Request conversion
       const response = await fetch('/api/convert-model', {
           method: 'POST',
           body: formData
@@ -345,11 +352,11 @@ const Dashboard = () => {
           throw new Error(errorData.error || "Failed to convert the model.");
       }
 
-      // 4. Download the newly converted file
+      // Download the newly converted file
       const convertedBlob = await response.blob();
       const downloadUrl = URL.createObjectURL(convertedBlob);
 
-      // NEW: Check if the backend sent a ZIP package (for colored OBJs)
+      // Check if the backend sent a ZIP package (for colored OBJs)
       let extension = downloadFormat;
       if (downloadFormat === 'obj' && convertedBlob.type === 'application/zip') {
           extension = 'zip';
@@ -375,27 +382,39 @@ const Dashboard = () => {
   const handleSaveJob = async () => {
     setIsSaving(true);
     try {
+      // Fetch the blob from the model viewer URL and convert to base64
+      let base64ModelData = null;
+      if (modelUrl && modelUrl.startsWith('blob:')) {
+        const response = await fetch(modelUrl);
+        const modelBlob = await response.blob();
+        base64ModelData = await blobToBase64(modelBlob);
+      }
+
+      // Build the payload with the base64 model string included
+      const payload = {
+        user: userName,
+        description: jobDescription,
+        input_prompt: isManualMode ? "N/A (Manual Upload)" : inputPrompt,
+        text_model: isManualMode ? "N/A" : selectedPromptService,
+        optimized_prompt: isManualMode ? "N/A" : optimizedPrompt,
+        image_model: isManualMode ? "Manual Upload" : selectedImageModel,
+        
+        // Pass the full selected/uploaded image to image_3 so the backend can grab and split it
+        image_1: isManualMode ? uploadedImage : (generatedImages[0]?.url || ""),
+        image_2: isManualMode ? "" : (generatedImages[1]?.url || ""),
+        image_3: isManualMode ? uploadedImage : selectedImageBase64,
+        image_4: isManualMode ? "" : (generatedImages[3]?.url || ""),
+        
+        three_d_model: selected3DModel,
+        model_link: "pending", 
+        model_data: base64ModelData,
+        analysis: jobAnalysis
+      };
+
       const response = await fetch('/api/save-job', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({
-          user: userName,
-          description: jobDescription,
-
-          // Conditionally submit prompt data based on the mode
-          input_prompt: isManualMode ? "N/A (Manual Upload)" : inputPrompt,
-          text_model: isManualMode ? "N/A" : selectedPromptService,
-          optimized_prompt: isManualMode ? "N/A" : optimizedPrompt,
-          image_model: isManualMode ? "Manual Upload" : selectedImageModel,
-
-          image_1: "pending", // TODO update when we are able to show images in google sheets
-          image_2: "pending",
-          image_3: "pending",
-          image_4: "pending",
-          three_d_model: selected3DModel,
-          model_link: "pending", // TODO update when we decide how to populate the model in gsheet
-          analysis: jobAnalysis
-        })
+        body: JSON.stringify(payload)
       });
 
       if (response.ok) {
@@ -405,6 +424,7 @@ const Dashboard = () => {
         setJobAnalysis("");
         setJobDescription("");
         setShowSaveModal(false);
+        alert("Job successfully saved and synced to Google Sheets/Drive!");
       } else {
         alert("Failed to save job to Sheets.");
       }
@@ -478,7 +498,7 @@ const Dashboard = () => {
         <section className="column">
           <div className="column-header">INPUT: Prompt Engineering</div>
 
-          {/* NEW: Mode Toggle */}
+          {/* Mode Toggle */}
           <div className="mode-toggle">
             <button
               className={`toggle-btn ${!isManualMode ? 'active' : ''}`}
@@ -571,7 +591,7 @@ const Dashboard = () => {
           <div className="column-header">PROCESSING & QUALITY CONTROL</div>
 
           {isManualMode ? (
-            /* NEW: Manual Upload UI */
+            /* Manual Upload UI */
             <div className="upload-container">
               <input
                 type="file"
@@ -616,7 +636,7 @@ const Dashboard = () => {
               )}
             </div>
           ) : (
-            /* EXISTING: Generated Image Grid */
+            /* Generated Image Grid */
             <div className="image-grid">
               {generatedImages.length === 0 && !isGenerating && (
                 <p style={{textAlign: 'center', width: '100%', color: '#888'}}>No images generated yet.</p>
@@ -764,7 +784,7 @@ const Dashboard = () => {
         </section>
       </main>
 
-      {/* NEW: MODAL OVERLAY PORTION (Add right before the final closing </div>) */}
+      {/* MODAL OVERLAY PORTION (Add right before the final closing </div>) */}
       {showSaveModal && (
         <div className="modal-overlay">
           <div className="modal-content">


### PR DESCRIPTION
Added support for image and model uploading to Google Sheets. 

Had to switch google authentication to Oauth because free service accounts cannot upload images. This means credentials.json has changed and its contents are located in the env sheet. Along with this, token.json is another file that validates you and should be placed in the same directory as credentials.json, under google_sheets_integration.

Images are split and placed into cells with attached hyperlinks for larger view. 3D models have the same hyperlink functionality.

When no credentials.json is found, instantiates mock services to bypass sheets integration entirely.